### PR TITLE
Use go 1.13 for builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,31 @@
-FROM debian:buster-slim
-ENV PATH=$PATH:/usr/local/go/bin
-ENV GOPATH=/go
+FROM golang:1.13
+LABEL io.tyk.vendor="Tyk" \
+      version="1.4" \
+      description="Base image for builds"
 
-ARG TYK_GW_TAG
-ENV TYK_GW_PATH=${GOPATH}/src/github.com/TykTechnologies/tyk
+ENV GOPATH=/
+ENV PACKER_VERSION="1.5.4"
 
 RUN apt-get update && apt-get dist-upgrade -y && \
-    apt-get install -y ca-certificates git curl jq build-essential libluajit-5.1-2 luarocks python3-setuptools python3-dev python3-pip
+    apt-get install -y ca-certificates \
+                       git \
+                       locales \
+                       curl \
+                       jq \
+                       rpm \
+                       dpkg-sig \
+                       build-essential \
+                       libluajit-5.1-2 \
+                       libluajit-5.1-dev \
+                       luarocks \
+                       python3-setuptools \
+                       python3-dev \
+                       python3-pip \
+                       ruby-dev 
 RUN luarocks install lua-cjson
-
-RUN pip3 install grpcio
-RUN pip3 install protobuf
-
-# Go install
-RUN curl -sL https://dl.google.com/go/go1.12.8.linux-amd64.tar.gz | tar -xzC /usr/local/
-
-RUN mkdir -p /go/src/plugin-build $TYK_GW_PATH
-COPY data/build.sh /build.sh
-RUN chmod +x /build.sh
-
-RUN curl -sL "https://api.github.com/repos/TykTechnologies/tyk/tarball/${TYK_GW_TAG}" | \
-    tar -C $TYK_GW_PATH --strip-components=1 -xzf -
-
-ENTRYPOINT ["/build.sh"]
+RUN pip3 install grpcio protobuf
+RUN mkdir -p $GOPATH ~/rpmbuild/SOURCES ~/rpmbuild/SPECS
+RUN go get github.com/mitchellh/gox 
+RUN gem install fpm rake package_cloud
+RUN curl https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip \
+        -o /tmp/packer.zip && cd /usr/local/bin && unzip /tmp/packer.zip

--- a/README.md
+++ b/README.md
@@ -1,40 +1,6 @@
 # tyk-build-env
 
-Docker environment used to build official images and plugins.
+Docker environment used to build official images.
 
-The usecase is that you have a plugin (probably Go) that you require
-to be built.
-
-## Building the plugin
-
-Navigate to where your plugin is and build using a docker volume to
-mount your code into the image. Since the vendor directory needs to be
-identical between the gateway build and the plugin build, this means
-that you should pull the version of this image corresponding to the
-gateway version you are using.
-
-This also implies that if your plugin has vendored modules that are
-[also used by Tyk
-gateway](https://github.com/TykTechnologies/tyk/tree/master/vendor)
-then your module will be overridden by the version that Tyk uses. 
-
-``` shell
-docker run -v `pwd`:/go/src/plugin-build tykio/tyk-plugin-compiler:v2.9.3 myplugin.so
-```
-
-You will find a `myplugin.so` in the current directory which is the file
-that goes into the API definition
-
-# Building the image
-
-This will build the image that will be used in the plugin build
-step. This section is for only for informational purposes.
-
-In the root of the repo:
-
-``` shell
-docker build --build-arg TYK_GW_TAG=v2.9.3 -t tyk-plugin-build-2.9.3 .
-```
-
-TYK_GW_TAG refers to the _tag_ in github corresponding to a released
-version.
+This is used as the base image for
+[tykio/plugin-compiler](https://hub.docker.com/r/tykio/tyk-plugin-compiler)


### PR DESCRIPTION
DO NOT MERGE.

Versioning is done by setting the version LABEL.

Currently, this image was being built from the gw repository. This image is now being used in building dashboard integration images too so it doesn't make sense to keep it in the gw repository any more. With this merged, we will once again work with hub autobuilds and things will make sense again.

This is in tandem with https://github.com/TykTechnologies/tyk/pull/3045