### PR TITLE
Restoring order

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,11 +16,12 @@ jobs:
     steps:
       - name: checkout tyk-build-env
         uses: actions/checkout@v2
-        
-      - name: push to docker hub
+
+      - name: push to github registry
         uses: docker/build-push-action@v1
         with:
-          username: alephnull
-          password: ${{ secrets.DH_PASSWORD }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: docker.pkg.github.com
           repository: tykio/tyk-build-env
           tag_with_ref: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,26 @@
+# Build and push a docker image 
+
+name: Integration image
+
+on:
+  push:
+    branches:
+      - gw
+      - db
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: checkout tyk-build-env
+        uses: actions/checkout@v2
+        
+      - name: push to docker hub
+        uses: docker/build-push-action@v1
+        with:
+          username: alephnull
+          password: ${{ secrets.DH_PASSWORD }}
+          repository: tykio/tyk-build-env
+          tag_with_ref: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 # Build and push a docker image 
 
-name: Integration image
+name: Publish image
 
 on:
   push:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,13 +1,12 @@
-# Build and push a docker image 
-
-name: Publish image
+name: Build image
 
 on:
+  pull_request:
   push:
     branches:
-      - gw
-      - db
       - master
+    tags:
+      - 'v*'
 
 jobs:
   build:
@@ -17,11 +16,36 @@ jobs:
       - name: checkout tyk-build-env
         uses: actions/checkout@v2
 
-      - name: push to github registry
-        uses: docker/build-push-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
         with:
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-          registry: docker.pkg.github.com
-          repository: tykio/tyk-build-env
-          tag_with_ref: true
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+            
+      - name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
+        with:
+          images: tykio/tyk-build-env
+          tags-sha: true
+          
+      - name: Login to DockerHub
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Build but push only for tags
+        uses: docker/build-push-action@v2
+        with:
+          file: ./Dockerfile
+          context: .
+          push: startsWith(github.ref, 'refs/tags/')
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          labels: ${{ steps.docker_meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,7 @@ FROM golang:1.12.17
 ENV PATH=$PATH
 ENV GOPATH=/go
 
-RUN apt-get update && apt-get dist-upgrade -y && \
-    apt-get install -y ca-certificates \
+RUN apt-get update && apt-get dist-upgrade -y ca-certificates \
                        git \
                        locales \
                        curl \
@@ -18,3 +17,8 @@ RUN luarocks install lua-cjson
 
 RUN pip3 install grpcio
 RUN pip3 install protobuf
+RUN mkdir -p $GOPATH && go get github.com/mitchellh/gox
+RUN gem install fpm
+
+ENV PACKER_VERSION=1.6.5
+RUN curl https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip -o /tmp/packer.zip && unzip /tmp/packer.zip -d /usr/local/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12.8
+FROM golang:1.12.17
 ENV PATH=$PATH
 ENV GOPATH=/go
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,20 @@
-FROM debian:buster-slim
-ENV PATH=$PATH:/usr/local/go/bin
+FROM golang:1.12.8
+ENV PATH=$PATH
 ENV GOPATH=/go
 
-ARG TYK_GW_TAG
-ENV TYK_GW_PATH=${GOPATH}/src/github.com/TykTechnologies/tyk
-
 RUN apt-get update && apt-get dist-upgrade -y && \
-    apt-get install -y ca-certificates git curl jq build-essential libluajit-5.1-2 luarocks python3-setuptools python3-dev python3-pip
+    apt-get install -y ca-certificates \
+                       git \
+                       locales \
+                       curl \
+                       jq \
+                       rpm \
+                       dpkg-sig \
+                       build-essential \
+                       libluajit-5.1-2  libluajit-5.1-dev luarocks \
+                       python3-setuptools python3-dev python3-pip \
+                       ruby-dev 
 RUN luarocks install lua-cjson
 
 RUN pip3 install grpcio
 RUN pip3 install protobuf
-
-# Go install
-RUN curl -sL https://dl.google.com/go/go1.12.8.linux-amd64.tar.gz | tar -xzC /usr/local/
-
-RUN mkdir -p /go/src/plugin-build $TYK_GW_PATH
-COPY data/build.sh /build.sh
-RUN chmod +x /build.sh
-
-RUN curl -sL "https://api.github.com/repos/TykTechnologies/tyk/tarball/${TYK_GW_TAG}" | \
-    tar -C $TYK_GW_PATH --strip-components=1 -xzf -
-
-ENTRYPOINT ["/build.sh"]

--- a/README.md
+++ b/README.md
@@ -1,40 +1,8 @@
 # tyk-build-env
 
-Docker environment used to build official images and plugins.
+Docker environment used to build official images and plugins which are used in:
+- Buddy pipelines
+- Github actions (ga branch)
+- Plugin compiler
 
-The usecase is that you have a plugin (probably Go) that you require
-to be built.
-
-## Building the plugin
-
-Navigate to where your plugin is and build using a docker volume to
-mount your code into the image. Since the vendor directory needs to be
-identical between the gateway build and the plugin build, this means
-that you should pull the version of this image corresponding to the
-gateway version you are using.
-
-This also implies that if your plugin has vendored modules that are
-[also used by Tyk
-gateway](https://github.com/TykTechnologies/tyk/tree/master/vendor)
-then your module will be overridden by the version that Tyk uses. 
-
-``` shell
-docker run -v `pwd`:/go/src/plugin-build tykio/tyk-plugin-compiler:v2.9.3 myplugin.so
-```
-
-You will find a `myplugin.so` in the current directory which is the file
-that goes into the API definition
-
-# Building the image
-
-This will build the image that will be used in the plugin build
-step. This section is for only for informational purposes.
-
-In the root of the repo:
-
-``` shell
-docker build --build-arg TYK_GW_TAG=v2.9.3 -t tyk-plugin-build-2.9.3 .
-```
-
-TYK_GW_TAG refers to the _tag_ in github corresponding to a released
-version.
+The dependencies in this Dockerfile is the union of gateway, dashboard and pump build-time dependencies.


### PR DESCRIPTION
Commit work that went into tags 1.3 and 1.4. 

With the github action in this PR, all the dockerhub auto-builds can be disabled. Pushes to Docker Hub are only for tags.

Please also add _Build image / build_ to the branch protection rules on master after merging.